### PR TITLE
DEVOPS-7283 move image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-inc/ansible-packer
+          repository: contrast-security-inc/ansible-packer-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v1
         with:
-          username: ${{ github.actor }}
+          username: ops-contrast
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io/contrast-security-oss
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           username: contrast-ops
           password: ${{ secrets.GHCR_PAT }}
-          registry: ghcr.io
+          registry: docker.pkg.github.com
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v1
         with:
-          username: ${{ github.actor }}
+          username: contrast-ops
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
-          registry: ghcr.io/contrast-security-oss
-          repository: contrast-security-oss/ansible-packer-docker/ansible-packer
+          registry: ghcr.io
+          repository: contrast-security-oss/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v1
         with:
-          username: ops-contrast
+          username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io/contrast-security-oss
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Build and push
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-oss/ansible-packer-docker
+          repository: contrast-security-oss/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-inc/ansible-packer-packer
+          repository: contrast-security-inc/ansible-packer-docker
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-oss/ansible-packer
+          repository: contrast-security-oss/ansible-packer-docker/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: Push image to ghcr
 on:
   push:
     branches:
-      - "DEVOPS-7283-move-image"
+      - "master"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v1
         with:
-          username: contrast-ops
+          username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: docker.pkg.github.com
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-oss/ansible-packer
+          repository: contrast-security-inc/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io/contrast-security-oss
           repository: contrast-security-oss/ansible-packer-docker/ansible-packer
           tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,22 @@
+name: Push image to ghcr
+
+on:
+  push:
+    branches:
+      - "DEVOPS-7283-move-image"
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+          registry: ghcr.io
+          repository: contrast-security-oss/ansible-packer-docker
+          tag_with_ref: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
-          repository: contrast-security-inc/ansible-packer-docker
+          repository: contrast-security-oss/ansible-packer
           tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.10
 ENV TERRAFORM_VERSION=0.12.8
 ENV ANSIBLE_VERSION=2.8.5
 ENV PACKER_VERSION=1.5.5
@@ -29,6 +29,19 @@ RUN \
     libffi-dev \
     bind-tools && \
   rm -rf /var/cache/apk/*
+
+RUN apk del ruby
+
+RUN wget --no-check-certificate -O ruby-install.tar.gz https://github.com/postmodern/ruby-install/archive/master.tar.gz
+RUN tar -xzvf ruby-install.tar.gz
+RUN cd ruby-install-master && make install
+RUN rm -rf /ruby-install-master && rm -rf /ruby-install.tar.gz
+
+RUN ruby-install --latest
+
+
+RUN gem update --system --no-document
+RUN gem install bundler --force
 
 RUN gem install --no-document inspec && \
     gem install --no-document inspec-bin  && \


### PR DESCRIPTION
- bumped alpine image
- upgraded ruby due to chef-utils dependency on >= 2.6.0 to install inspec
- push image to ghcr