### PR TITLE
Devops 0 inspec fix

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "devops-0-rspec-fix"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "devops-0-rspec-fix"
 
 jobs:
   push_to_registry:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN \
   curl  \
   jq \
   build-base \
-  ruby-dev \
   libxml2-dev \
   libffi-dev \
+  openssl-dev \
   bind-tools && \
   rm -rf /var/cache/apk/*
 
@@ -33,7 +33,7 @@ RUN tar -xzvf ruby-install.tar.gz
 RUN cd ruby-install-master && make install
 RUN rm -rf /ruby-install-master && rm -rf /ruby-install.tar.gz
 
-RUN ruby-install --latest ruby
+RUN ruby-install --system --latest ruby
 
 RUN gem update --system --no-document
 RUN gem install bundler --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN tar -xzvf ruby-install.tar.gz
 RUN cd ruby-install-master && make install
 RUN rm -rf /ruby-install-master && rm -rf /ruby-install.tar.gz
 
-RUN ruby-install --latest
-
+RUN ruby-install --latest ruby
 
 RUN gem update --system --no-document
 RUN gem install bundler --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,32 +5,28 @@ ENV PACKER_VERSION=1.5.5
 
 RUN \
   apk add --update-cache \
-    docker \
-    openssh-client \
-    git \
-    python-dev \
-    python \
-    py-yaml \
-    py-jinja2 \
-    py-crypto \
-    py-boto \
-    py-futures \
-    py-pip \
-    py-boto \
-    python3 \
-    bash \
-    curl  \
-    jq \
-    ruby \
-    ruby-io-console \
-    build-base \
-    ruby-dev \
-    libxml2-dev \
-    libffi-dev \
-    bind-tools && \
+  docker \
+  openssh-client \
+  git \
+  python-dev \
+  python \
+  py-yaml \
+  py-jinja2 \
+  py-crypto \
+  py-boto \
+  py-futures \
+  py-pip \
+  py-boto \
+  python3 \
+  bash \
+  curl  \
+  jq \
+  build-base \
+  ruby-dev \
+  libxml2-dev \
+  libffi-dev \
+  bind-tools && \
   rm -rf /var/cache/apk/*
-
-RUN apk del ruby
 
 RUN wget --no-check-certificate -O ruby-install.tar.gz https://github.com/postmodern/ruby-install/archive/master.tar.gz
 RUN tar -xzvf ruby-install.tar.gz
@@ -43,22 +39,22 @@ RUN gem update --system --no-document
 RUN gem install bundler --force
 
 RUN gem install --no-document inspec && \
-    gem install --no-document inspec-bin  && \
-    apk del build-base
+  gem install --no-document inspec-bin  && \
+  apk del build-base
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
 RUN curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
-    rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+  unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
+  rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN \
   pip install --upgrade \
-    pip \
-    boto3 \
-    botocore \
-    awscli
+  pip \
+  boto3 \
+  botocore \
+  awscli
 
 RUN \
   mkdir /ansible && \


### PR DESCRIPTION
Something unfortunate happened to the imaging pipeline https://bitbucket.org/contrastsecurity/imaging/addon/pipelines/home#!/results/1957

It feels like this repo got pushed into dockehub's :latest

Turns out ruby-install, wasn't (and/or alpine system ruby was taking precedence).

Removing alpine ruby + installing via ruby-install restores inspect - packer is able to proceed. https://bitbucket.org/contrastsecurity/imaging/addon/pipelines/home#!/results/1965